### PR TITLE
npm update at Wed Jul 27 2016 02:13:48 GMT+0000 (UTC)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-npm-update",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "dependencies": {
     "@types/empower": {
       "version": "0.0.28",
@@ -38,9 +38,9 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-4.3.26.tgz"
     },
     "acorn": {
-      "version": "3.2.0",
-      "from": "acorn@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.2.0.tgz"
+      "version": "3.3.0",
+      "from": "acorn@3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
     },
     "acorn-es7-plugin": {
       "version": "1.0.17",
@@ -113,9 +113,9 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
-      "version": "1.1.5",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
+      "version": "1.1.6",
+      "from": "brace-expansion@1.1.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "call-signature": {
       "version": "0.0.2",
@@ -308,6 +308,18 @@
         }
       }
     },
+    "glob": {
+      "version": "3.2.11",
+      "from": "glob@3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+        }
+      }
+    },
     "graceful-readlink": {
       "version": "1.0.1",
       "from": "graceful-readlink@>=1.0.0",
@@ -440,6 +452,11 @@
       "from": "jsprim@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
     },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
     "make-error": {
       "version": "1.2.0",
       "from": "make-error@>=1.1.1 <2.0.0",
@@ -461,14 +478,21 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
     },
     "minimist": {
-      "version": "0.0.8",
-      "from": "minimist@0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      "version": "0.0.10",
+      "from": "minimist@0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
       "from": "mkdirp@0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
     },
     "moment": {
       "version": "2.14.1",
@@ -586,9 +610,9 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
     },
     "request": {
-      "version": "2.73.0",
-      "from": "request@>=2.40.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
+      "version": "2.74.0",
+      "from": "request@2.74.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz"
     },
     "resolve": {
       "version": "1.1.7",
@@ -678,9 +702,9 @@
       "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
     },
     "tough-cookie": {
-      "version": "2.2.2",
-      "from": "tough-cookie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+      "version": "2.3.1",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
     },
     "traverse": {
       "version": "0.6.6",
@@ -688,9 +712,9 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
     },
     "tsconfig": {
-      "version": "5.0.2",
-      "from": "tsconfig@>=5.0.2 <6.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-5.0.2.tgz"
+      "version": "5.0.3",
+      "from": "tsconfig@5.0.3",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-5.0.3.tgz"
     },
     "tunnel-agent": {
       "version": "0.4.3",


### PR DESCRIPTION
## Updaing Dependencies
- acorn: [v3.2.0...v3.3.0](https://github.com/ternjs/acorn/compare/v3.2.0...v3.3.0)
- brace-expansion: [v1.1.5...v1.1.6](https://github.com/juliangruber/brace-expansion/compare/v1.1.5...v1.1.6)
- minimist: [v0.0.8...v0.0.10](https://github.com/substack/minimist/compare/v0.0.8...v0.0.10)
- request: [v2.73.0...v2.74.0](https://github.com/request/request/compare/v2.73.0...v2.74.0)
- tough-cookie: [v2.2.2...v2.3.1](https://github.com/SalesforceEng/tough-cookie/compare/v2.2.2...v2.3.1)
- tsconfig: [v5.0.2...v5.0.3](https://github.com/TypeStrong/tsconfig/compare/v5.0.2...v5.0.3)
- glob https://github.com/isaacs/node-glob
- lru-cache https://github.com/isaacs/node-lru-cache

Powered by [ci-npm-update](https://github.com/gfx/ci-npm-update)
