### PR TITLE
add --dev to `npm shrinkwrap`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,6 +12,11 @@
       "from": "@types/form-data@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.28.tgz"
     },
+    "@types/mocha": {
+      "version": "2.2.28",
+      "from": "@types/mocha@>=2.2.28 <3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.28.tgz"
+    },
     "@types/moment": {
       "version": "2.11.28",
       "from": "@types/moment@>=2.11.28 <3.0.0",
@@ -21,6 +26,11 @@
       "version": "4.0.30",
       "from": "@types/node@>=4.0.30 <5.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-4.0.30.tgz"
+    },
+    "@types/power-assert": {
+      "version": "0.0.27",
+      "from": "@types/power-assert@0.0.27",
+      "resolved": "https://registry.npmjs.org/@types/power-assert/-/power-assert-0.0.27.tgz"
     },
     "@types/power-assert-formatter": {
       "version": "0.0.26",
@@ -485,6 +495,28 @@
       "from": "mkdirp@0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
+    "mocha": {
+      "version": "2.5.3",
+      "from": "mocha@>=2.5.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "from": "commander@2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "from": "escape-string-regexp@1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "from": "supports-color@1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
+        }
+      }
+    },
     "moment": {
       "version": "2.14.1",
       "from": "moment@>=2.14.1 <3.0.0",
@@ -539,6 +571,11 @@
       "version": "2.0.1",
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+    },
+    "power-assert": {
+      "version": "1.4.1",
+      "from": "power-assert@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.1.tgz"
     },
     "power-assert-context-formatter": {
       "version": "1.0.7",
@@ -697,10 +734,49 @@
       "from": "traverse@>=0.6.6 <0.7.0",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
     },
+    "ts-node": {
+      "version": "1.2.2",
+      "from": "ts-node@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-1.2.2.tgz",
+      "dependencies": {
+        "diff": {
+          "version": "2.2.3",
+          "from": "diff@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
+    },
     "tsconfig": {
       "version": "5.0.3",
       "from": "tsconfig@>=5.0.2 <6.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-5.0.3.tgz"
+    },
+    "tslint": {
+      "version": "3.14.0",
+      "from": "tslint@>=3.13.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-3.14.0.tgz",
+      "dependencies": {
+        "diff": {
+          "version": "2.2.3",
+          "from": "diff@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
+        },
+        "glob": {
+          "version": "7.0.5",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
+        }
+      }
     },
     "tunnel-agent": {
       "version": "0.4.3",
@@ -716,6 +792,11 @@
       "version": "2.0.2",
       "from": "type-name@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz"
+    },
+    "typescript": {
+      "version": "2.0.0",
+      "from": "typescript@>=2.0.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.0.tgz"
     },
     "underscore.string": {
       "version": "3.3.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,8 @@ export function createGitBranch(branch: string): Promise<ShrinkWrap> {
         // https://github.com/npm/npm/issues/11876
         return run("rm -rf node_modules npm-shrinkwrap.json ; npm install");
     }).then(() => {
-        return run("npm shrinkwrap");
+        // https://github.com/npm/npm/issues/11189
+        return run("npm shrinkwrap --dev");
     }).then(() => {
         return run("git add npm-shrinkwrap.json");
     }).then(() => {


### PR DESCRIPTION
it's because `npm shrinkwrap` does not include part of devDependencies
but production services should manage all the dependencies
