### PR TITLE
Add git+ssh schema to allowed url

### DIFF
--- a/src/compare_view.ts
+++ b/src/compare_view.ts
@@ -3,10 +3,6 @@ import { GitHubApi } from "./github";
 
 export class GitHubCompareView {
 
-    // url can be:
-    // git+https://github.com/foo/bar.git
-    // https://github.com/foo/bar.baz.git
-    // git@github.com:foo/bar.git
     static fixupUrl(repository: { url: string }): string | null {
         if (!(repository && repository.url)) {
             return null;

--- a/src/github.ts
+++ b/src/github.ts
@@ -33,9 +33,9 @@ export class GitHubApi {
             "http:\\/\\/",
             "https:\\/\\/",
         ];
-        const hostRgexp = "([^\\/:]+)[\\/:]";
+        const hostRegexp = "([^\\/:]+)[\\/:]";
         const pathRegexp = "([^\\/]+)\\/([^\\/]+)(?!\\.git)";
-        const matched = new RegExp(`^(?:${schemeRegexps.join("|")})${hostRgexp}${pathRegexp}$`).exec(url);
+        const matched = new RegExp(`^(?:${schemeRegexps.join("|")})${hostRegexp}${pathRegexp}$`).exec(url);
         if (!matched) {
             throw Error(`Cannot parse git repository URL: ${url}`);
         }

--- a/src/github.ts
+++ b/src/github.ts
@@ -26,34 +26,23 @@ export class GitHubApi {
         // http://github.com/foo/bar.baz.git
         // https://github.com/foo/bar.baz.git
         const schemeRegexps = [
-            "(?:git:\\/\\/)",
-            "(?:git@)",
-            "(?:git\\+https:\\/\\/)",
-            "(?:git\\+ssh:\\/\\/git@)",
-            "(?:http:\\/\\/)",
-            "(?:https:\\/\\/)",
+            "git:\\/\\/",
+            "git@",
+            "git\\+https:\\/\\/",
+            "git\\+ssh:\\/\\/git@",
+            "http:\\/\\/",
+            "https:\\/\\/",
         ];
-        let host: string = "";
-        let owner: string = "";
-        let repository: string = "";
-        schemeRegexps.forEach((schemeRegexp) => {
-            const hostRgexp = "([^\\/:]+)[\\/:]";
-            const pathRegexp = "([^\\/]+)\\/([^\\/]+)(?!\\.git)";
-            const matched = new RegExp(`^${schemeRegexp}${hostRgexp}${pathRegexp}$`).exec(url);
-            if (matched) {
-                host = matched[1];
-                owner = matched[2];
-                repository = matched[3].replace(/\.git$/, "");
-                return;
-            }
-        });
-        if (host === "" || owner === "" || repository === "") {
+        const hostRgexp = "([^\\/:]+)[\\/:]";
+        const pathRegexp = "([^\\/]+)\\/([^\\/]+)(?!\\.git)";
+        const matched = new RegExp(`^(?:${schemeRegexps.join("|")})${hostRgexp}${pathRegexp}$`).exec(url);
+        if (!matched) {
             throw Error(`Cannot parse git repository URL: ${url}`);
         }
         return {
-            host,
-            owner,
-            repository,
+            host: matched[1],
+            owner: matched[2],
+            repository: matched[3].replace(/\.git$/, ""),
         };
     }
 

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -3,11 +3,13 @@ import { GitHubApi } from "../src/github";
 import { NpmConfig } from "../src/npm_config";
 
 const githubDataSet = {
-    "github ssh url": "git@github.com:foo/something.useful.git",
-    "github https url": "https://github.com/foo/something.useful",
-    "github http url": "http://github.com/foo/something.useful",
-    "github https+git url": "https://github.com/foo/something.useful.git",
     "github git url": "git://github.com/foo/something.useful.git",
+    "github git+https url": "git+https://github.com/foo/something.useful.git",
+    "github git+ssh url": "git+ssh://git@github.com/foo/something.useful.git",
+    "github http url": "http://github.com/foo/something.useful",
+    "github https url": "https://github.com/foo/something.useful",
+    "github https with git extension url": "https://github.com/foo/something.useful.git",
+    "github ssh url": "git@github.com:foo/something.useful.git",
 };
 const gheDataSet = {
     "ghe ssh url": "git@ghe.example.com:foo/something.useful.git",


### PR DESCRIPTION
Add git+ssh schema to allowed url.
Because an exception thrown when including git+ssh schema in npm update package.

ex, gulp-csscomb
[gulp-csscomb npm config](http://registry.npmjs.org/gulp-csscomb/3.0.8)

```
Unexpected errors caught: Error: Cannot parse git repository URL: git+ssh://git@github.com/koistya/gulp-csscomb.git
    at Error (native)
    at Function.parseUrl (/home/ubuntu/hoge/node_modules/ci-npm-update/lib/github.js:14:19)
    at Function.fixupUrl (/home/ubuntu/hoge/node_modules/ci-npm-update/lib/compare_view.js:18:39)
    at new GitHubCompareView (/home/ubuntu/hoge/node_modules/ci-npm-update/lib/compare_view.js:8:48)
    at result.push.npm_config_1.NpmConfig.getFromRegistry.then (/home/ubuntu/hoge/node_modules/ci-npm-update/lib/shrink_wrap.js:70:24)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```
