### PR TITLE
npm update at Sat Oct 01 2016 17:03:24 GMT+0000 (UTC)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
     },
     "@types/node": {
       "version": "6.0.41",
-      "from": "@types/node@>=6.0.0 <7.0.0",
+      "from": "@types/node@>=6.0.41 <7.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.41.tgz"
     },
     "@types/power-assert": {
@@ -33,14 +33,9 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
     },
     "acorn-es7-plugin": {
-      "version": "1.0.17",
+      "version": "1.1.0",
       "from": "acorn-es7-plugin@>=1.0.12 <2.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.0.17.tgz"
-    },
-    "amdefine": {
-      "version": "1.0.0",
-      "from": "amdefine@>=0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
@@ -100,14 +95,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.0",
       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-      "dependencies": {
-        "tweetnacl": {
-          "version": "0.14.3",
-          "from": "tweetnacl@>=0.14.3 <0.15.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
     },
     "bl": {
       "version": "1.1.2",
@@ -515,9 +503,9 @@
       }
     },
     "moment": {
-      "version": "2.15.0",
+      "version": "2.15.1",
       "from": "moment@>=2.14.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.0.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
     },
     "ms": {
       "version": "0.7.1",
@@ -655,14 +643,14 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "source-map": {
-      "version": "0.1.32",
-      "from": "source-map@0.1.32",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+      "version": "0.5.6",
+      "from": "source-map@>=0.5.3 <0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
     },
     "source-map-support": {
-      "version": "0.4.2",
+      "version": "0.4.3",
       "from": "source-map-support@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -670,9 +658,9 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
-      "version": "1.10.0",
+      "version": "1.10.1",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -764,9 +752,9 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
         },
         "glob": {
-          "version": "7.0.6",
+          "version": "7.1.0",
           "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz"
         },
         "minimatch": {
           "version": "3.0.3",
@@ -781,9 +769,9 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tweetnacl": {
-      "version": "0.13.3",
-      "from": "tweetnacl@>=0.13.0 <0.14.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+      "version": "0.14.3",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
     },
     "type-name": {
       "version": "2.0.2",
@@ -791,9 +779,9 @@
       "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz"
     },
     "typescript": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "from": "typescript@>=2.0.0",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.3.tgz"
     },
     "underscore.string": {
       "version": "3.3.4",


### PR DESCRIPTION
## Dependencies declared in package.json
- moment: [v2.15.0...v2.15.1](https://github.com/moment/moment/compare/v2.15.0...v2.15.1)
## DevDependencies declared in package.json
- source-map-support: [v0.4.2...v0.4.3](https://github.com/evanw/node-source-map-support/compare/v0.4.2...v0.4.3)
- typescript: [v2.0.2...v2.0.3](https://github.com/Microsoft/TypeScript/compare/v2.0.2...v2.0.3)
## Dependencies not declared in package.json
- acorn-es7-plugin: [v1.0.17...v1.1.0](https://github.com/MatAtBread/acorn-es7-plugin/compare/v1.0.17...v1.1.0)
- source-map: [v0.1.32...v0.5.6](https://github.com/mozilla/source-map/compare/v0.1.32...v0.5.6)
- sshpk: [v1.10.0...v1.10.1](https://github.com/arekinath/node-sshpk/compare/v1.10.0...v1.10.1)
- tweetnacl: [v0.13.3...v0.14.3](https://github.com/dchest/tweetnacl-js/compare/v0.13.3...v0.14.3)

Powered by [bitjourney/ci-npm-update](https://github.com/bitjourney/ci-npm-update)
