### PR TITLE
npm update at Fri Oct 07 2016 17:03:35 GMT+0000 (UTC)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33,9 +33,9 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
     },
     "acorn-es7-plugin": {
-      "version": "1.1.1",
+      "version": "1.1.3",
       "from": "acorn-es7-plugin@>=1.0.12 <2.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.3.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
@@ -563,19 +563,19 @@
       "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.1.tgz"
     },
     "power-assert-context-formatter": {
-      "version": "1.0.7",
+      "version": "1.1.0",
       "from": "power-assert-context-formatter@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.0.tgz"
     },
     "power-assert-context-reducer-ast": {
-      "version": "1.0.7",
+      "version": "1.1.0",
       "from": "power-assert-context-reducer-ast@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.0.tgz"
     },
     "power-assert-context-traversal": {
-      "version": "1.0.7",
-      "from": "power-assert-context-traversal@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.0.7.tgz"
+      "version": "1.1.0",
+      "from": "power-assert-context-traversal@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.0.tgz"
     },
     "power-assert-formatter": {
       "version": "1.4.1",
@@ -583,29 +583,34 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz"
     },
     "power-assert-renderer-assertion": {
-      "version": "1.0.7",
+      "version": "1.1.0",
       "from": "power-assert-renderer-assertion@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.0.tgz"
     },
     "power-assert-renderer-base": {
-      "version": "1.0.7",
-      "from": "power-assert-renderer-base@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.0.7.tgz"
+      "version": "1.1.0",
+      "from": "power-assert-renderer-base@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.1.0.tgz"
     },
     "power-assert-renderer-comparison": {
-      "version": "1.0.7",
+      "version": "1.1.0",
       "from": "power-assert-renderer-comparison@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.0.tgz"
     },
     "power-assert-renderer-diagram": {
-      "version": "1.0.7",
+      "version": "1.1.0",
       "from": "power-assert-renderer-diagram@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.0.tgz"
     },
     "power-assert-renderer-file": {
-      "version": "1.0.7",
+      "version": "1.1.0",
       "from": "power-assert-renderer-file@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.0.tgz"
+    },
+    "power-assert-util-string-width": {
+      "version": "1.1.0",
+      "from": "power-assert-util-string-width@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.0.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -720,14 +725,14 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
     },
     "ts-node": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "from": "ts-node@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-1.4.0.tgz",
       "dependencies": {
         "diff": {
-          "version": "2.2.3",
-          "from": "diff@>=2.1.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
+          "version": "3.0.0",
+          "from": "diff@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.0.0.tgz"
         },
         "minimist": {
           "version": "1.2.0",
@@ -817,6 +822,11 @@
       "version": "4.0.1",
       "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yn": {
+      "version": "1.2.0",
+      "from": "yn@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-1.2.0.tgz"
     }
   }
 }


### PR DESCRIPTION
## DevDependencies declared in package.json
- ts-node: [v1.3.0...v1.4.0](https://github.com/TypeStrong/ts-node/compare/v1.3.0...v1.4.0)
## Dependencies not declared in package.json
- acorn-es7-plugin: [v1.1.1...v1.1.3](https://github.com/MatAtBread/acorn-es7-plugin/compare/v1.1.1...v1.1.3)
- power-assert-context-formatter: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-context-reducer-ast: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-context-traversal: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-renderer-assertion: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-renderer-base: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-renderer-comparison: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-renderer-diagram: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-renderer-file: [v1.0.7...v1.1.0](https://github.com/twada/power-assert-runtime/compare/v1.0.7...v1.1.0)
- power-assert-util-string-width https://github.com/twada/power-assert-runtime
- yn https://github.com/sindresorhus/yn

Powered by [bitjourney/ci-npm-update](https://github.com/bitjourney/ci-npm-update)
