### PR TITLE
Stdout maxBuffer exceeded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,10 @@ import * as moment from "moment";
 function run(command: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         console.log(`>> ${command}`);
-        exec(command, "utf8", (error, stdout, stderr) => {
+        exec(command, {
+            encoding: "utf8",
+            maxBuffer: 1024 * 1024,
+        }, (error, stdout, stderr) => {
             if (stdout.length > 0) {
                 console.log(stdout);
             }


### PR DESCRIPTION
When there are many output content, `maxBuffer exceed` error occurs. 
The default `maxBuffer` value is 200kb. So I increase the `maxBuffer` value.
